### PR TITLE
Reverse up/down servo joint angles

### DIFF
--- a/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
+++ b/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
@@ -72,6 +72,7 @@ static const ServoConfig kUpDownServoConfig = {
             .max_potentiometer_angle = {250},
             .min_potentiometer_angle_as_joint_angle = {0.F},
             .joint_angle_to_potentiometer_angle_ratio = 1.F,
+            .is_reversed = true,
         },
 };
 


### PR DESCRIPTION
We want the up/down angle to be 0 when the arm is aimed straight down. Currently, the potentiometer angle increases as the arm moves down and decreases as the arm moves up. By setting `is_reversed`, we make sure that the joint angle reverses the relationship, so that the joint angle instead decreases as the arm moves down and increases as the arm moves up.