### PR TITLE
Shoulder: Modify upper arm rotation min angle

### DIFF
--- a/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
+++ b/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
@@ -131,7 +131,7 @@ static const stepper_control_config_t kUpperArmRotationStepperConfig = {
             // Red is Vin and black is ground.
             .min_potentiometer_angle = {50},
             .max_potentiometer_angle = {130},
-            .min_potentiometer_angle_as_joint_angle = {-40.F},
+            .min_potentiometer_angle_as_joint_angle = {-50.F},
             .joint_angle_to_potentiometer_angle_ratio = 1.F,
         },
 };


### PR DESCRIPTION
The arm's rotation at 0 degrees didn't have the arm facing straight forward.