### PR TITLE
Servo: Use a frequency of 330 Hz instead of 50 Hz

### DIFF
--- a/src/esp32/components/servo/servo.c
+++ b/src/esp32/components/servo/servo.c
@@ -25,8 +25,8 @@ typedef struct {
 
 enum {
   SERVO_MAX_DUTY = ((1U << LEDC_TIMER_13_BIT) - 1),
-  // We assume that the frequency used by the servo is 50 Hz.
-  SERVO_FREQUENCY = 50,
+  // We assume that the frequency used by the servo is 330 Hz.
+  SERVO_FREQUENCY = 330,
   SERVO_PERIOD_US = 1000000UL / SERVO_FREQUENCY,
 };
 


### PR DESCRIPTION
The HV2060 supports a frequency of 330 Hz, so setting it to 330 Hz we make sure we are able to update the pulse width as fast as possible. Since we update the velocity of the motors with a frequency of 100 Hz, having a frequency of 50 Hz also makes it so we end up skipping every other velocity motor update since we try to set the new pulse width in the middle of the previous one.