### PR TITLE
Add context manager functionality to SocketCANInterface

### DIFF
--- a/src/hardware/can/can_socketcan.py
+++ b/src/hardware/can/can_socketcan.py
@@ -1,7 +1,10 @@
 
 import can
 import time
+from types import TracebackType
 from typing import List, Optional
+from typing_extensions import Self
+
 from .can_interface import CANInterface, CANMessage
 from .can_message_parser import CANMessageParser
 
@@ -24,6 +27,20 @@ class SocketCANInterface(CANInterface):
         self.rx_count = 0
         self.tx_count = 0
         self.error_count = 0
+
+    def __enter__(self) -> Self:
+        """Automatically start the CAN bus when using a `with` statement."""
+        self.start()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Automatically stop the CAN bus when exiting a `with` statement."""
+        self.stop()
 
     def start(self) -> bool:
         """Start the CAN bus with standard 11-bit CAN IDs only."""

--- a/src/hardware/can/test_socketcan.py
+++ b/src/hardware/can/test_socketcan.py
@@ -316,6 +316,36 @@ def test_statistics():
     return True
 
 
+def test_context_manager():
+    """Test context manager (__enter__/__exit__) functionality."""
+    print_section("Test 7: Context Manager")
+
+    print("\n1. Testing context manager entry and exit...")
+    context_interface = None
+
+    with SocketCANInterface(interface="can0", bitrate=1000000) as can_interface:
+        context_interface = can_interface
+        if can_interface.is_running():
+            print("   ✓ Interface started successfully in __enter__")
+        else:
+            print("   ✗ Failed to start interface in __enter__")
+            print("   Make sure:")
+            print("     - CAN interface is set up (run scripts/agx_setup_can.sh)")
+            print("     - Interface is up: ip link set can0 up")
+            print("     - python-can is installed: pip install python-can")
+            return False
+
+    print("\n2. Verifying interface stopped after context exit...")
+    assert context_interface is not None, "Context interface should be set"
+    if not context_interface.is_running():
+        print("   ✓ Interface stopped successfully in __exit__")
+    else:
+        print("   ✗ Interface should be stopped after context exit")
+        return False
+
+    return True
+
+
 def main():
     """Run all tests."""
     print("\n" + "=" * 60)
@@ -334,6 +364,7 @@ def main():
         ("Loopback Mode", test_loopback),
         ("Error Handling", test_error_handling),
         ("Statistics", test_statistics),
+        ("Context Manager", test_context_manager),
     ]
     
     results = []


### PR DESCRIPTION
This allows `with SocketCANInterface(...) as can_interface:` statements to be used, making sure that the CAN interface is always automatically stopped.