### PR TITLE
Call abort() instead of returning from the app_main

### DIFF
--- a/src/esp32/human_lower_arm_module/main/main.c
+++ b/src/esp32/human_lower_arm_module/main/main.c
@@ -20,7 +20,7 @@ void app_main(void) {
   EventGroupHandle_t sync_group = xEventGroupCreate();
   if (sync_group == NULL) {
     ESP_LOGE(TAG_MAIN, "Critical Error: Could not create Event Group!");
-    return;
+    abort();
   }
 
   /**
@@ -38,6 +38,7 @@ void app_main(void) {
    */
   if (ble_service_start(sync_group, streaming_mask) != ESP_OK) {
     ESP_LOGE(TAG_MAIN, "Failed to start BLE Service!");
+    abort();
   } else {
     ESP_LOGI(TAG_MAIN,
              "BLE Service Running: Listening for Micro-Streaming events.");
@@ -49,6 +50,7 @@ void app_main(void) {
   // 5. Start IMU Service (I2C Scanning & 100Hz Task)
   if (imu_service_start(sync_group) != ESP_OK) {
     ESP_LOGE(TAG_MAIN, "Failed to start IMU Service!");
+    abort();
   } else {
     ESP_LOGI(TAG_MAIN, "IMU Service Running.");
   }
@@ -57,6 +59,7 @@ void app_main(void) {
   // This starts the high-speed continuous sampling engine
   if (adc_service_init(sync_group) != ESP_OK) {
     ESP_LOGE(TAG_MAIN, "Failed to start ADC Service!");
+    abort();
   } else {
     ESP_LOGI(TAG_MAIN, "ADC Service Running.");
   }

--- a/src/esp32/robot_elbow_module/main/main.c
+++ b/src/esp32/robot_elbow_module/main/main.c
@@ -361,7 +361,7 @@ void app_main(void) {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to initialize CAN driver: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
     ESP_LOGI(TAG, "CAN initialized (TX=%d, RX=%d, %d baud)", CAN_TX_PIN,
              CAN_RX_PIN, CAN_BAUDRATE);
@@ -376,7 +376,7 @@ void app_main(void) {
     if (err) {
       ESP_LOGE(TAG, "Failed to initialize IMU driver: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
     ESP_LOGI(TAG, "IMU initialized (SDA=%d, SCL=%d)", imu_cfg.sda_pin,
              imu_cfg.scl_pin);
@@ -388,7 +388,7 @@ void app_main(void) {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to initialize ADC manager: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
     ESP_LOGI(TAG, "ADC manager initialized");
   }
@@ -407,7 +407,7 @@ void app_main(void) {
                      &s_elbow_stepper_handle);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Failed to initialize elbow stepper");
-      return;
+      abort();
     }
   }
   s_adc_mgr_elbow_buffer->length = 0;
@@ -426,21 +426,21 @@ void app_main(void) {
                                  TASK_CAN_RX_PRIORITY, NULL);
     if (err != pdPASS) {
       ESP_LOGE(TAG, "Failed to create can_rx task, err code: %d");
-      return;
+      abort();
     }
 
     err = xTaskCreate(imu_task, "imu_task", TASK_STACK_DEPTH, NULL,
                       TASK_IMU_PRIORITY, NULL);
     if (err != pdPASS) {
       ESP_LOGE(TAG, "Failed to create imu task, err code: %d");
-      return;
+      abort();
     }
 
     err = xTaskCreate(stepper_task, "stepper_task", TASK_STACK_DEPTH, NULL,
                       TASK_STEPPER_UPDATE_PRIORITY, NULL);
     if (err != pdPASS) {
       ESP_LOGE(TAG, "Failed to create stepper task, err code: %d");
-      return;
+      abort();
     }
 
     // Lower priority than stepper_task.

--- a/src/esp32/robot_hand_motor_module/main/main.c
+++ b/src/esp32/robot_hand_motor_module/main/main.c
@@ -115,6 +115,7 @@ void app_main() {
     ESP_ERROR_CHECK_WITHOUT_ABORT(imu_init(&imu_config));
     if (!imu_is_present()) {
       ESP_LOGW(TAG, "IMU isn't present");
+      abort();
     }
   }
 
@@ -132,7 +133,7 @@ void app_main() {
     esp_err_t err = can_init(CAN_TX_PIN, CAN_RX_PIN, CAN_BAUDRATE, NULL);
     if (err) {
       ESP_LOGE(TAG, "Couldn't start can driver: %s", esp_err_to_name(err));
-      return;
+      abort();
     }
   }
 

--- a/src/esp32/robot_hand_pressure_module/main/main.c
+++ b/src/esp32/robot_hand_pressure_module/main/main.c
@@ -3,6 +3,7 @@
 
 #include "adc_service.h"
 #include "can_driver.h"
+#include "esp_err.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -47,12 +48,18 @@ void app_main(void) {
 
   if (init_adc_service() != ESP_OK) {
     ESP_LOGE(TAG, "ADC Service Init Failed!");
-    return;
+    abort();
   }
 
   // 2. Initialize CAN Bus
-  can_init(CAN_TX_GPIO, CAN_RX_GPIO, CAN_BAUDRATE, NULL);
-  ESP_LOGI(TAG, "CAN Bus Initialized ");
+  {
+    esp_err_t err = can_init(CAN_TX_GPIO, CAN_RX_GPIO, CAN_BAUDRATE, NULL);
+    if (err != ESP_OK) {
+      ESP_LOGE(TAG, "Failed to initialize CAN: %s", esp_err_to_name(err));
+      abort();
+    }
+    ESP_LOGI(TAG, "CAN Bus Initialized ");
+  }
 
   while (1) {
     loop_control();

--- a/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
+++ b/src/esp32/robot_shoulder_module/main/robot_shoulder_module.c
@@ -482,7 +482,7 @@ void app_main(void) {
     esp_err_t err = can_init(CAN_TX_GPIO, CAN_RX_GPIO, 1000000, &can_filter);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Error calling can_init: %s", esp_err_to_name(err));
-      return;
+      abort();
     }
   }
 
@@ -491,7 +491,7 @@ void app_main(void) {
     esp_err_t err = adc_mgr_init(kAdcMgrConfig);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Error calling adc_mgr_init: %s", esp_err_to_name(err));
-      return;
+      abort();
     }
   }
 
@@ -501,7 +501,7 @@ void app_main(void) {
     esp_err_t err = adc_mgr_read(&s_adc_read_results, 0);
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Error calling adc_mgr_read: %s", esp_err_to_name(err));
-      return;
+      abort();
     }
 
     s_latest_potentiometer_up_down_value =
@@ -523,7 +523,7 @@ void app_main(void) {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Error calling servos_init for up/down servo: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
 
     err = servo_init(&kLeftRightServoConfig,
@@ -533,7 +533,7 @@ void app_main(void) {
     if (err != ESP_OK) {
       ESP_LOGE(TAG, "Error calling servos_init for left/right servo: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
 
     err = stepper_init(&kUpperArmRotationStepperConfig,
@@ -544,7 +544,7 @@ void app_main(void) {
       ESP_LOGE(TAG,
                "Error calling stepper_init for upper arm rotation stepper: %s",
                esp_err_to_name(err));
-      return;
+      abort();
     }
   }
 


### PR DESCRIPTION
Returning from app_main means the system stays in the state it's in at the point of the return, meaning that other tasks that have been created keep on running and pins that have been configured stay active unless deinitialized. 

Calling abort() instead induces a panic and reboots the system. This also helps with e.g. the IMU connection, which sometimes takes a couple of reboots to actually establish a proper connection.