### PR TITLE
Motors: Don't print warning every time ADC values are suspicious

### DIFF
--- a/src/esp32/components/servo/servo.c
+++ b/src/esp32/components/servo/servo.c
@@ -189,12 +189,17 @@ bool servo_update(ServoHandle handle, uint16_t ms_until_next_period,
     // situation where the ADC values are off (maybe a loose wire or the
     // potentiometer is configured incorrectly, for example). In that situation,
     // we want to err on the side of caution and not move the motor.
-    ESP_LOGW(TAG,
-             "Potentiometer angle %f is close to its limits of [0, %f]. "
-             "Turning off motor as a safety precaution",
-             current_angle.degree,
-             ctx->cfg.potentiometer.degrees_of_motion.degree);
     servo_apply_velocity(handle, (AngularVelocity){0});
+    static int i = 0;
+    // Don't print every time to avoid triggering the task watchdog.
+    if (--i < 0) {
+      i = 50;
+      ESP_LOGW(TAG,
+               "Potentiometer angle %f is close to its limits of [0, %f]. "
+               "Turning off motor as a safety precaution",
+               current_angle.degree,
+               ctx->cfg.potentiometer.degrees_of_motion.degree);
+    }
     return true;
   }
 

--- a/src/esp32/components/stepper/src/stepper.c
+++ b/src/esp32/components/stepper/src/stepper.c
@@ -377,11 +377,18 @@ void stepper_update(stepper_control_handle_t handle, uint16_t dt_ms,
     // situation where the ADC values are off (maybe a loose wire or the
     // potentiometer is configured incorrectly, for example). In that situation,
     // we want to err on the side of caution and not move the motor.
-    ESP_LOGW(TAG,
-             "Potentiometer angle %f is close to its limits of [0, %f]. "
-             "Turning off motor as a safety precaution",
-             angle_deg.degree, ctx->cfg.potentiometer.degrees_of_motion.degree);
     stop_motor(handle);
+    static int i = 0;
+    // Don't print every time to avoid triggering the task watchdog.
+    if (--i < 0) {
+      i = 50;
+
+      ESP_LOGW(TAG,
+               "Potentiometer angle %f is close to its limits of [0, %f]. "
+               "Turning off motor as a safety precaution",
+               angle_deg.degree,
+               ctx->cfg.potentiometer.degrees_of_motion.degree);
+    }
     return;
   }
 


### PR DESCRIPTION
Printing every time risks triggering the task watchdog.